### PR TITLE
ci: env-var passthrough for tag/version in release.yml shell blocks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,8 +61,11 @@ jobs:
       - name: Preflight — verify okto-pulse-core has matching tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pass step output through env to avoid inline interpolation in
+          # the shell body (audit H1 — script injection via tag names).
+          # Matches the BRANCH: pattern in ci.yml.
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
-          TAG="${{ steps.version.outputs.tag }}"
           if ! gh api "repos/OktoLabsAI/okto-pulse-core/git/refs/tags/$TAG" --silent 2>/dev/null; then
             echo "::error::okto-pulse-core is not tagged $TAG."
             echo "::error::Tag and push core BEFORE pulse:"
@@ -85,9 +88,12 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify pyproject.toml version matches git tag
+        env:
+          # Pass step output through env to avoid inline interpolation in
+          # the shell body (audit H1 — script injection via tag names).
+          TAG_VERSION: ${{ steps.version.outputs.version }}
         run: |
           PYPROJECT_VERSION=$(grep -E '^version' okto-pulse/pyproject.toml | head -1 | sed -E 's/.*"(.*)".*/\1/')
-          TAG_VERSION="${{ steps.version.outputs.version }}"
           if [ "$PYPROJECT_VERSION" != "$TAG_VERSION" ]; then
             echo "::error::okto-pulse/pyproject.toml version ($PYPROJECT_VERSION) does not match git tag ($TAG_VERSION)"
             echo "::error::Bump version in pyproject.toml, commit, then re-tag."


### PR DESCRIPTION
Closes audit finding **H1** (script-injection defense-in-depth in release pipeline).

Converts inline `${{ steps.version.outputs.* }}` interpolations inside the **preflight** and **version-verify** shell bodies to `env:` passthrough. Matches the existing `BRANCH:` pattern in `ci.yml`'s sibling-checkout step.

### Why hardening, not an active fix
The repo's tag-protection ruleset (`Protect release tags v*`) blocks malformed tag names today, so this is consistency / defense-in-depth rather than an active vector. Worth doing because the pattern should be uniform across both workflows and any new `run:` block will inherit the right idiom.

### Verification
- `yaml.safe_load` parses clean
- No behavioral change to the pipeline — same shell, just `$TAG` / `$TAG_VERSION` come from `env:` instead of being inlined
- Will be exercised on the next release tag