### PR TITLE
ci: governance files (CODEOWNERS, dependabot, SECURITY, PR template)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Code owners — auto-assigned as reviewers on PRs touching these paths.
+# https://docs.github.com/en/repositories/managing-your-repositories-settings-and-security/customizing-your-repository/about-code-owners
+
+# Default owner for everything.
+*                              @Maheidem
+
+# Build / CI / release infrastructure.
+/.github/                      @Maheidem
+/Dockerfile                    @Maheidem
+/deploy/                       @Maheidem
+/.github/replay-fixtures/      @Maheidem
+
+# Lockfile + dep manifests — changes to these alter what ships.
+/uv.lock                       @Maheidem
+/pyproject.toml                @Maheidem

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "docker"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## What does this PR do?
+
+Brief description of the change.
+
+## Related Issue
+
+Closes #
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation
+- [ ] Refactoring
+- [ ] Other (describe):
+
+## Checklist
+
+- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
+- [ ] I agree to the [CLA](../CLA.md) by submitting this PR
+- [ ] My changes follow the existing code style
+- [ ] I have tested my changes locally
+- [ ] I have updated documentation (if applicable)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,71 @@
+# Security Policy
+
+## Supported Versions
+
+Only the most recent minor release line receives security fixes. Older
+versions are end-of-life and will not receive patches.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.1.x   | :white_check_mark: |
+| < 0.1   | :x:                |
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability in `okto-pulse`,
+please report it privately so we can work on a fix before it becomes
+public. **Please do not open a public GitHub issue for vulnerability
+reports.**
+
+### How to report
+
+Use GitHub's **private vulnerability reporting** feature on this
+repository: https://github.com/OktoLabsAI/okto-pulse/security/advisories/new
+
+If you cannot use GitHub's reporting flow, email
+**security@oktolabs.ai** with:
+
+- a description of the vulnerability and its impact,
+- steps to reproduce (proof-of-concept welcome),
+- any version, configuration, or environment details that affect the
+  attack surface,
+- whether you intend to publish your own write-up, and on what timeline.
+
+### What to expect
+
+- **Acknowledgement** within **2 business days** of receipt.
+- **Initial triage and severity assessment** within **5 business days**.
+- **Fix timeline** depends on severity:
+  - Critical: target patch within 7 days.
+  - High: target patch within 14 days.
+  - Medium / Low: rolled into the next normal release.
+- We aim to coordinate disclosure with the reporter. Public disclosure
+  happens after a fix ships, unless an in-the-wild exploit forces an
+  earlier announcement.
+
+### Scope
+
+In scope:
+- Code in this repository (CLI, frontend bundle).
+- Code in the companion engine repo,
+  [okto-pulse-core](https://github.com/OktoLabsAI/okto-pulse-core).
+- The published Docker image
+  `ghcr.io/oktolabsai/okto-pulse`.
+- Default configuration shipped with the above.
+
+Out of scope:
+- Third-party dependencies (please report upstream first; if you
+  believe our usage compounds the issue, include that in the report).
+- User-deployed instances we do not operate.
+- Social-engineering attacks against project maintainers.
+
+## Coordinated Disclosure
+
+By submitting a report you agree to give us a reasonable window to
+patch before any public discussion. We will credit reporters who wish
+to be credited once a fix has shipped.
+
+## Related Documents
+
+- [Contributing Guide](./CONTRIBUTING.md) — general contribution flow.
+- [CLA](./CLA.md) — required for accepted code contributions.


### PR DESCRIPTION
Closes audit findings:
- **M3** (no CODEOWNERS — review routing depends on memory)
- **M4** (no dependabot — security-relevant deps drift unflagged)
- **L2** (no SECURITY.md — no documented vuln-report path)
- **L3** (no PR template — inconsistent PR descriptions)

### Files
- `.github/CODEOWNERS` — Maheidem owns everything; explicit on CI/build/release infra paths
- `.github/dependabot.yml` — weekly pip / actions / docker scans, capped at 5/5/3 open PRs
- `.github/pull_request_template.md` — mirrored from okto-pulse-core
- `SECURITY.md` — vuln-reporting flow with GitHub private advisories + email fallback, supported-versions table, scope, SLAs

### Verification
- `yaml.safe_load` parses dependabot.yml clean
- Once merged, the next PR will automatically request review from `@Maheidem` per CODEOWNERS
- Dependabot starts opening PRs within ~7 days