### PR TITLE
build: remove obsolete MCP host sed patch from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@
 #
 # Both targets:
 #   - Pre-download all-MiniLM-L6-v2 so the container starts offline-capable.
-#   - Patch the MCP server to bind 0.0.0.0 (the core hardcodes 127.0.0.1 which
-#     is unreachable from the host even with -p 8101:8101). Controlled at
-#     runtime via MCP_HOST env var (default 0.0.0.0).
+#   - Set MCP_HOST=0.0.0.0 (in docker-compose.yml) so the MCP server is
+#     reachable across the docker network. core/mcp/server.py reads MCP_HOST
+#     from the environment natively (default 127.0.0.1).
 #   - Correct data/KG dir env vars: DATA_DIR and KG_BASE_DIR (the legacy
 #     OKTO_PULSE_DATA_DIR env var is not read by the Python code).
 #
@@ -107,13 +107,9 @@ RUN python -c "from sentence_transformers import SentenceTransformer; SentenceTr
     else \
         echo "WARNING: HF_MODEL_SHA256 not set — skipping integrity check. Pin the SHA above to enable." ; \
     fi
-# Patch: replace the hardcoded 127.0.0.1 in MCP server with an env-var lookup.
-# Uses find rather than importlib to avoid triggering the import chain at build time.
-# grep -q asserts the patch applied — fails the build if the line was renamed upstream.
-# (Phase 4a will move this into core source so the patch can be removed.)
-RUN SERVER_PY=$(find /usr/local/lib -name "server.py" -path "*/okto_pulse/core/mcp/server.py" | head -1) \
- && sed -i 's|host="127.0.0.1", port=port|host=os.environ.get("MCP_HOST", "0.0.0.0"), port=port|' "$SERVER_PY" \
- && grep -q 'MCP_HOST' "$SERVER_PY"
+# MCP host binding: read from MCP_HOST env var (default 127.0.0.1, set to
+# 0.0.0.0 in docker-compose.yml). Upstreamed into okto-pulse-core source
+# in OktoLabsAI/okto-pulse-core#10; no Dockerfile patch needed anymore.
 EXPOSE 8100 8101
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
     CMD curl -fsS http://127.0.0.1:8100/api/v1/kg/settings || exit 1
@@ -140,9 +136,9 @@ RUN python -c "from sentence_transformers import SentenceTransformer; SentenceTr
     else \
         echo "WARNING: HF_MODEL_SHA256 not set — skipping integrity check. Pin the SHA above to enable." ; \
     fi
-RUN SERVER_PY=$(find /usr/local/lib -name "server.py" -path "*/okto_pulse/core/mcp/server.py" | head -1) \
- && sed -i 's|host="127.0.0.1", port=port|host=os.environ.get("MCP_HOST", "0.0.0.0"), port=port|' "$SERVER_PY" \
- && grep -q 'MCP_HOST' "$SERVER_PY"
+# MCP host binding: read from MCP_HOST env var (default 127.0.0.1, set to
+# 0.0.0.0 in docker-compose.yml). Upstreamed into okto-pulse-core source
+# in OktoLabsAI/okto-pulse-core#10; no Dockerfile patch needed anymore.
 EXPOSE 8100 8101
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
     CMD curl -fsS http://127.0.0.1:8100/api/v1/kg/settings || exit 1


### PR DESCRIPTION
Phase 4a — companion to OktoLabsAI/okto-pulse-core#10.

The Dockerfile's `sed`/`grep` block patched `core/mcp/server.py` at build time so the MCP server could read `MCP_HOST` from the environment. With #10 upstreaming that read into source, the patch is now redundant.

### Removed
- 'Patch:' comment block + 6 lines of sed/grep in both `local-runtime` and `pypi-runtime` stages
- Stale top-of-file comment that described the patch behaviour

### Sequencing
**Must merge AFTER okto-pulse-core#10.** Once #10 is on main, pulse's Docker build picks up the upstreamed env-var read via sibling-checkout (release.yml) or wheel install (CI). Merging this PR before #10 still produces a buildable image (docker-proxy bridges 127.0.0.1 inside the container), but defeats the audit's intent.

### Stacked
This branch is stacked on top of `ci/reproducible-image` (PR #5, Phase 2a). When #5 merges first, GitHub auto-retargets this PR to main and the diff stays clean.

### Verification
`docker build --target local-runtime` succeeded locally end-to-end with sibling on `ci/upstream-mcp-host`.