### PR TITLE
feat(cli): okto-pulse api-key subcommand + use it in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,15 +218,19 @@ jobs:
           docker logs okto-pulse-ci | tail -80
           exit 1
 
-      - name: Extract API key from container logs
+      - name: Extract API key from container
         id: apikey
         run: |
-          # The container prints the bootstrap API key (dash_<hex>) to stdout on
-          # first boot. Grep it out — proven reliable in the migration task.
-          API_KEY=$(docker logs okto-pulse-ci 2>&1 | grep -oE 'dash_[a-f0-9]+' | head -1 || true)
-          if [ -z "$API_KEY" ]; then
-            echo "::error::Could not find API key (dash_<hex>) in container logs"
-            docker logs okto-pulse-ci | tail -50
+          # Read the bootstrap key directly from the seeded DB inside the
+          # running container via the dedicated CLI subcommand. More
+          # robust than grepping logs (which is sensitive to log-format
+          # changes). Banner is printed to stderr so 2>/dev/null leaves
+          # only the key on stdout.
+          API_KEY=$(docker exec okto-pulse-ci okto-pulse api-key 2>/dev/null | tr -d '\r\n')
+          if [ -z "$API_KEY" ] || ! echo "$API_KEY" | grep -qE '^dash_[a-f0-9]+$'; then
+            echo "::error::okto-pulse api-key did not return a valid dash_<hex> key"
+            echo "::error::Got: '$API_KEY'"
+            docker logs okto-pulse-ci | tail -30
             exit 1
           fi
           echo "::add-mask::$API_KEY"

--- a/src/okto_pulse/community/cli.py
+++ b/src/okto_pulse/community/cli.py
@@ -294,6 +294,53 @@ def cmd_status(args):
     print(f"  MCP server ({mcp_port}):  {'running' if mcp_up else 'stopped'}")
 
 
+def cmd_api_key(args):
+    """Print the bootstrap API key (the dash_<hex> seeded by `okto-pulse init`).
+
+    Reads directly from the SQLite database to avoid coupling to the
+    running API server. Used by the release pipeline (release.yml) to
+    extract the key for replay smoke tests without grepping log output.
+
+    Exit codes:
+      0 — key printed
+      1 — DB missing, no agents seeded, or agent has no api_key
+
+    Output format: a single line containing the key on stdout. Banner
+    goes to stderr so this is safe to pipe.
+    """
+    import sqlite3
+    from okto_pulse.community.config import CommunitySettings
+
+    settings = CommunitySettings()
+    db_path = Path(settings.data_dir) / "data" / "pulse.db"
+
+    if not db_path.exists():
+        print(f"Database not found at {db_path}. Run 'okto-pulse init' first.", file=sys.stderr)
+        sys.exit(1)
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        # The default seed creates exactly one agent ("Local Agent") with a
+        # bootstrap dash_<hex> key. Take the oldest seeded agent so we keep
+        # returning the same value across restarts even if more agents are
+        # added later.
+        row = conn.execute(
+            "SELECT api_key FROM agents WHERE api_key IS NOT NULL "
+            "ORDER BY created_at ASC LIMIT 1"
+        ).fetchone()
+    except sqlite3.OperationalError as exc:
+        print(f"Database not initialised: {exc}. Run 'okto-pulse init' first.", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        conn.close()
+
+    if row is None or not row[0]:
+        print("No bootstrap API key found in database.", file=sys.stderr)
+        sys.exit(1)
+
+    print(row[0])
+
+
 def cmd_verify_pipeline(args):
     """Run the 5 pipeline health checks against a board.
 
@@ -725,6 +772,13 @@ def main():
         help=f"MCP server port (default: {DEFAULT_MCP_PORT})",
     )
     sub_status.set_defaults(func=cmd_status)
+
+    # api-key — print bootstrap dash_<hex> from the seeded DB.
+    sub_apikey = subparsers.add_parser(
+        "api-key",
+        help="Print the bootstrap API key (dash_<hex>) seeded by 'okto-pulse init'",
+    )
+    sub_apikey.set_defaults(func=cmd_api_key)
 
     # reset
     sub_reset = subparsers.add_parser("reset", help="Delete all data and re-seed")


### PR DESCRIPTION
Phase 4b — stable bootstrap API key extraction.

The release pipeline previously extracted the bootstrap `dash_<hex>` key by grepping container stdout. That worked but coupled the gate to the log format: any change to the seed message would silently break the smoke test.

### Changes

**`src/okto_pulse/community/cli.py`** — new `cmd_api_key` reads `agents.api_key` directly from the SQLite DB and prints it on stdout (banner stays on stderr so the output is pipe-safe). Registered as the `okto-pulse api-key` subcommand.

**`.github/workflows/release.yml`** — replace `docker logs ... | grep -oE 'dash_[a-f0-9]+'` with `docker exec okto-pulse-ci okto-pulse api-key`. Stricter validation: the result must match `^dash_[a-f0-9]+$` or the step fails loudly.

### Verification

Local smoke test (built `local-runtime` image, ran container, exec'd the subcommand): returned a valid `dash_<hex>` key in <100ms with the banner correctly redirected to stderr.

### Stacked
Stacked on top of `ci/release-sign-scan` (PR #7). When #7 merges first the diff against main becomes a clean superset.