### PR TITLE
ci: bump GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout okto-pulse
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: okto-pulse
 
@@ -52,7 +52,7 @@ jobs:
           fi
 
       - name: Checkout okto-pulse-core @ ${{ steps.core_ref.outputs.ref }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: OktoLabsAI/okto-pulse-core
           ref: ${{ steps.core_ref.outputs.ref }}
@@ -60,7 +60,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Build verify only — no GHCR push on PR/main.
       # Context is the workspace root because the Dockerfile uses sibling layout
@@ -68,7 +68,7 @@ jobs:
       # No pytest gate — see release.yml for rationale (smoke + MCP replay
       # on tag push is the behavioral gate).
       - name: Docker build (verify only, not pushed)
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: okto-pulse/Dockerfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,12 +78,12 @@ jobs:
           echo "okto-pulse-core has matching tag $TAG"
 
       - name: Checkout okto-pulse @ ${{ steps.version.outputs.tag }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: okto-pulse
 
       - name: Checkout okto-pulse-core @ ${{ steps.version.outputs.tag }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: OktoLabsAI/okto-pulse-core
           ref: ${{ steps.version.outputs.tag }}
@@ -110,7 +110,7 @@ jobs:
           echo "Versions aligned: pulse=$PYPROJECT_VERSION core=$CORE_VERSION tag=$TAG_VERSION"
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: pip
@@ -132,7 +132,7 @@ jobs:
       # green on Linux runners.
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Install cosign
         # Pinned to commit SHA of v4.1.1 (released 2026-03-26) for
@@ -141,7 +141,7 @@ jobs:
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -149,7 +149,7 @@ jobs:
 
       - name: Compute image tags + labels
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE }}
           # Standard semver tags driven by the git tag (vMAJOR.MINOR.PATCH).
@@ -161,7 +161,7 @@ jobs:
             type=sha,format=short,prefix=sha-
 
       - name: Build image (load locally for smoke test, no push yet)
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: okto-pulse/Dockerfile


### PR DESCRIPTION
Phase 4c — removes the every-run Node 20 deprecation warnings and gets ahead of the September 2026 cliff.

### Bumps
| Action | Before | After |
|--------|--------|-------|
| actions/checkout | v4 | v6 |
| actions/setup-python | v5 | v6 |
| docker/setup-buildx-action | v3 | v4 |
| docker/login-action | v3 | v4 |
| docker/metadata-action | v5 | v6 |
| docker/build-push-action | v5 | v7 |

actions/setup-python v6 explicitly upgrades dependencies for Node 24 (upstream PR #1259). The Docker actions ship Node 24 in their respective major bumps.

### Stacked
On top of `ci/api-key-cli` (PR #9) so this picks up Phase 1a + Phase 3 + Phase 4b release.yml state. When the upstream PRs (#4 #7 #9) merge first, this PR's diff against main becomes a clean superset.

### Risk
Major version bumps may have breaking changes. CI on this PR will exercise the bumped versions on `docker build verify` — that's the immediate signal. The release pipeline change is not exercised until a tag push, so a follow-up smoke-test tag (e.g. `v0.1.12-rc1`) is recommended after merge.