### PR TITLE
ci: post Slack notification when release pipeline fails

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -322,6 +322,31 @@ jobs:
         run: |
           docker rm -f okto-pulse-ci 2>/dev/null || true
 
+      - name: Notify Slack on failure
+        # Posts a one-line failure to the webhook stored in the
+        # RELEASE_FAILURE_WEBHOOK repo secret. If the secret is unset,
+        # the step logs a warning and exits 0 (release pipeline state is
+        # already "failed" — we don't want this notification step to
+        # mask the original failure).
+        # Closes audit Phase 4e.
+        if: failure()
+        env:
+          WEBHOOK: ${{ secrets.RELEASE_FAILURE_WEBHOOK }}
+          TAG: ${{ steps.version.outputs.tag }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -z "$WEBHOOK" ]; then
+            echo "::warning::RELEASE_FAILURE_WEBHOOK secret is not set — skipping Slack notification."
+            echo "::warning::To enable, run: gh secret set RELEASE_FAILURE_WEBHOOK -R OktoLabsAI/okto-pulse"
+            exit 0
+          fi
+          curl --fail-with-body --silent --show-error \
+            -X POST -H 'Content-Type: application/json' \
+            --data @- \
+            "$WEBHOOK" <<EOF
+          {"text": ":rotating_light: okto-pulse release \`${TAG:-(unknown)}\` failed.\nRun: ${RUN_URL}"}
+          EOF
+
       - name: Job summary
         if: success()
         env:


### PR DESCRIPTION
Phase 4e — wire failure notifications.

Adds an `if: failure()` step at the end of the release job that posts a one-line failure notification to a Slack incoming webhook. URL lives in the `RELEASE_FAILURE_WEBHOOK` repo secret.

### Setup required from @Maheidem before this is useful

```bash
gh secret set RELEASE_FAILURE_WEBHOOK -R OktoLabsAI/okto-pulse \
  --body 'https://hooks.slack.com/services/...'
```

If the secret is unset when a release fails, the notify step logs a warning and exits 0 — the pipeline state is already 'failed' so this auxiliary step must not mask the original failure.

### Implementation choice
Uses `curl` directly rather than `slackapi/slack-github-action` — fewer moving parts, no third-party action to SHA-pin, the payload is just a JSON-text Slack incoming-webhook send. If we ever need block kit / threading, swap to the action.

### Stacked
On top of `ci/replay-fixture-extract` (Phase 4d). When upstream PRs merge first the diff against main becomes a clean superset.

### What you'll see on a real failure
```
🚨 okto-pulse release  failed.
Run: https://github.com/OktoLabsAI/okto-pulse/actions/runs/<id>
```