### PR TITLE
ci(release): split build into smoke (no provenance) + push (with provenance)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,6 +161,13 @@ jobs:
             type=sha,format=short,prefix=sha-
 
       - name: Build image (load locally for smoke test, no push yet)
+        # Two-build pattern: this load-into-daemon build cannot include
+        # provenance/SBOM attestations because newer buildx (>=0.13)
+        # produces a manifest list when those are enabled, and `load: true`
+        # cannot import manifest lists into the local Docker daemon
+        # ("docker exporter does not currently support exporting manifest
+        # lists"). The release-push step below rebuilds with provenance +
+        # SBOM enabled, hitting the buildx cache so the rebuild is cheap.
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -170,11 +177,8 @@ jobs:
           load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          # SLSA build provenance + CycloneDX SBOM, attached as image
-          # attestations. They travel with the image when pushed; consumers
-          # can verify via `cosign download attestation` (audit C6).
-          provenance: true
-          sbom: true
+          provenance: false
+          sbom: false
 
       - name: Scan image for HIGH/CRITICAL vulns (trivy)
         # Pinned to commit SHA of v0.36.0 (released 2026-04-22) for
@@ -284,15 +288,24 @@ jobs:
 
           echo "All replay gates passed"
 
-      - name: Push tagged images to GHCR
-        env:
-          DOCKER_TAGS: ${{ steps.meta.outputs.tags }}
-        run: |
-          while IFS= read -r tag; do
-            [ -z "$tag" ] && continue
-            echo "Pushing $tag"
-            docker push "$tag"
-          done <<< "$DOCKER_TAGS"
+      - name: Build and push to GHCR with attestations
+        # Second build: rebuilds with the same context + Dockerfile so the
+        # buildx cache from the smoke-test build is reused (cheap), then
+        # pushes to GHCR with provenance + SBOM attestations attached.
+        # We can't reuse the locally-loaded image because that build had
+        # provenance/sbom disabled (manifest-list incompatibility with
+        # `load: true`). Closes audit C6 (SLSA provenance) + C5 (signed
+        # supply chain — cosign signs the pushed manifest list below).
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: okto-pulse/Dockerfile
+          target: local-runtime
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: true
+          sbom: true
 
       - name: Sign images (cosign keyless)
         # Sign each pushed tag with a Sigstore-issued certificate (no


### PR DESCRIPTION
Fixes the v0.1.12 release pipeline failure: `docker exporter does not currently support exporting manifest lists`.

Buildx >=0.13 produces a manifest list when provenance/SBOM are enabled. The release.yml build step uses both `load: true` (smoke test) and `provenance: true` / `sbom: true` (attestations). The local Docker daemon cannot load manifest lists, so the build fails before smoke can run.

Worked silently on older buildx; v0.1.12 (May 1) hit it after the runner upgrade between v0.1.11 (Apr 30) and v0.1.12 (May 1).

## Fix

Two-build pattern:
1. **Smoke build** — `load: true, provenance: false, sbom: false` -> loads single-platform image into local daemon for smoke + replay
2. **Release push** — `push: true, provenance: true, sbom: true` -> rebuilds (buildx cache hit, cheap), pushes manifest list to GHCR with attestations

Cosign signing on the pushed manifest list is unchanged. SLSA + SBOM attestations still ship.

## Recovery

This is the prerequisite to re-running the v0.1.12 release. After merge, the v0.1.12 tag will be force-rewritten to point at the new main HEAD (gorilla mode — explicit user instruction).

