### PR TITLE
ci(release): trivyignore for fastmcp CVE-2026-32871, CVE-2026-27124

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,6 +186,9 @@ jobs:
         # of the released image. ignore-unfixed=true skips findings with
         # no upstream fix yet — those would block every release on
         # vendor patch latency.
+        # trivyignores: okto-pulse/.trivyignore lists CVEs that have been
+        # triaged and accepted (e.g., fastmcp 2.x CVEs whose fix requires
+        # a major-version bump tracked in a follow-up).
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ env.IMAGE }}:${{ steps.version.outputs.version }}
@@ -193,6 +196,7 @@ jobs:
           exit-code: '1'
           severity: 'HIGH,CRITICAL'
           ignore-unfixed: true
+          trivyignores: okto-pulse/.trivyignore
 
       - name: Spin up container
         run: |

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,16 @@
+# Documented CVE exceptions for the v0.1.12 release.
+#
+# Both CVEs are in fastmcp 2.14.7. Fixed in fastmcp 3.2.0 (major-version
+# upgrade). The okto-pulse-core pyproject pins fastmcp>=2.0.0,<3.0.0 because
+# the +622-line MCP server expansion in src/okto_pulse/core/mcp/server.py
+# was written against fastmcp 2.x APIs and a major-version migration needs
+# its own validation pass.
+#
+# Tracked separately for follow-up bump to fastmcp >=3.2.0,<4.0.0 (already
+# proposed by dependabot PR #16 in okto-pulse-core).
+#
+# Format: one CVE per line, # for comments. Comments after CVE on same line
+# are not part of the CVE id.
+
+CVE-2026-32871
+CVE-2026-27124


### PR DESCRIPTION
Both CVEs are in fastmcp 2.14.7 (current core dep pin: >=2.0.0,<3.0.0). Both fixed in fastmcp 3.2.0, but the migration to 3.x is a major-version bump that needs its own validation pass against the +622-line MCP server expansion.

Tracked for follow-up via okto-pulse-core dependabot PR #16 which proposes the wider <4.0.0 pin.

Adds:
- .trivyignore listing the 2 CVEs with rationale
- release.yml: passes trivyignores: okto-pulse/.trivyignore to the trivy action

This unblocks the v0.1.12 release pipeline.