### PR TITLE
docs: preserve Docker architecture docs from retired dev branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,128 @@ actual engine.
 
 ---
 
+## Docker architecture
+
+The deployable artifact is a single image: `ghcr.io/oktolabsai/okto-pulse:<tag>`.
+Everything else (compose files, wheels, attestations) is produced from this repo
+plus the `okto-pulse-core` sibling.
+
+### Multi-stage Dockerfile
+
+```
+python:3.14-slim (digest-pinned)
+    │
+    ├─ base                  apt deps + python env
+    │
+    ├─ wheel-builder         COPY okto-pulse/ + okto-pulse-core/ (siblings)
+    │                        → python -m build → /wheels/*.whl
+    │   ↓
+    ├─ local-install         COPY pyprojects + uv.lock → uv pip install
+    │                        --frozen → /wheels/*.whl on top
+    │   ↓
+    └─ local-runtime         pre-download all-MiniLM-L6-v2,
+                             verify HF_MODEL_SHA256, EXPOSE 8100/8101,
+                             HEALTHCHECK, CMD ["okto-pulse", "serve"]
+    │
+    ├─ pypi-install          uv pip install okto-pulse==${OKTO_PULSE_VERSION}
+    │   ↓
+    └─ pypi-runtime          same finalizer as local-runtime
+```
+
+Two **independent finalizer paths** (`local-runtime`, `pypi-runtime`) so dev and
+prod don't share an install layer that could mask a publishing bug. They emit
+the same runtime contract: ports 8100/8101, `okto-pulse serve` as PID 1, healthcheck on
+`/api/v1/kg/settings`, model cache at `/opt/hf-cache`.
+
+### Compose files
+
+| File | Target | Build context | When to use |
+|------|--------|----------------|-------------|
+| `docker-compose.yml` | `local-runtime` | `..` (parent of `okto-pulse/`) | Hacking on `okto-pulse-core/` and `okto-pulse/` together. Wheels built from local source. |
+| `docker-compose.prod.yml` | `pypi-runtime` | `.` | Pulling a pinned `okto-pulse==X.Y.Z` from PyPI. No sibling repo needed. |
+
+Both bind host ports to `127.0.0.1` only and set `HOST=0.0.0.0` /
+`MCP_HOST=0.0.0.0` inside the container so port-mapping actually reaches the
+listeners. (Without those env vars, uvicorn binds to the container's loopback
+interface and Docker's port mapping silently produces "Connection reset by peer"
+on the host side.)
+
+### Why the sibling-checkout pattern
+
+The `local-runtime` target needs both repos at the same commit/tag so an image
+built in CI is reproducible from source. The release pipeline does sibling
+checkouts of `okto-pulse-core@vX.Y.Z` and `okto-pulse@vX.Y.Z`, sets the build
+context to the parent directory, and the Dockerfile's `wheel-builder` stage
+`COPY`s both into `/src/`. The `okto-pulse/pyproject.toml` dep pin
+(`okto-pulse-core>=X.Y.Z,<1.0.0`) is a floor for the PyPI install path; it does
+NOT control which core source is built into the local-runtime image.
+
+### Env vars the runtime reads
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `HOST` | `127.0.0.1` | API/UI uvicorn bind host. Read by `CommunitySettings.host` (pydantic-settings, no prefix). |
+| `MCP_HOST` | `127.0.0.1` | MCP uvicorn bind host. Read by `community/main.py` (since v0.1.12) AND `core/mcp/server.py:run_mcp_server()` standalone. |
+| `DATA_DIR` | `~/.okto-pulse` | SQLite + KG root. Set to `/data` in compose. |
+| `KG_BASE_DIR` | derived from `DATA_DIR` | Per-board graph storage. |
+| `HF_HOME` | `~/.cache/huggingface` | Pre-warmed to `/opt/hf-cache` in the image. |
+| `MCP_PORT` / API port | from CLI flags or `settings.mcp_port` / `settings.port` | Override port numbers without remapping in compose. |
+| `MCP_TRACE_ENABLED` | unset | `=1` records every MCP call to `${MCP_TRACE_DIR}/session_*.jsonl`. |
+
+**MCP_HOST runtime path gotcha:** there are TWO uvicorn callers in the codebase.
+`okto-pulse-core/.../mcp/server.py:run_mcp_server()` is only used when running
+the MCP server standalone (`python -m okto_pulse.core.mcp.server`). The
+deployed container runs `okto-pulse serve`, which uses the dual-port runner in
+`okto-pulse/src/okto_pulse/community/main.py`. Both honor `MCP_HOST` since
+v0.1.12 — but pre-v0.1.12 only the standalone path did. If anyone backports
+older releases, watch for the regression: setting `MCP_HOST=0.0.0.0` would do
+nothing inside the container.
+
+### Healthcheck
+
+```
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD curl -fsS http://127.0.0.1:8100/api/v1/kg/settings || exit 1
+```
+
+The healthcheck curls **inside the container** so it always uses 127.0.0.1
+even when the public binding is 0.0.0.0. A container can be `healthy` but
+unreachable from the host if the listener bound to 127.0.0.1 (uvicorn loopback
+inside container ≠ Docker's NAT loopback). Always check the uvicorn startup
+line in `docker logs` when "container healthy + curl fails from host":
+
+```
+INFO:     Uvicorn running on http://0.0.0.0:8100   ← reachable
+INFO:     Uvicorn running on http://127.0.0.1:8100 ← NOT reachable from host
+```
+
+### Local Docker dry-run
+
+To replicate the release pipeline's smoke build locally (sibling layout, build
+context = workspace root):
+
+```bash
+cd ..                         # workspace root holding both repos
+docker build \
+  -f okto-pulse/Dockerfile \
+  --target local-runtime \
+  -t pulse:dev \
+  .
+
+docker run --rm -d --name pulse-dev \
+  -e HOST=0.0.0.0 \
+  -e MCP_HOST=0.0.0.0 \
+  -p 18100:8100 -p 18101:8101 \
+  pulse:dev
+docker logs -f pulse-dev   # ctrl-c when "Startup complete"
+curl -fsS http://localhost:18100/api/v1/kg/settings
+docker rm -f pulse-dev
+```
+
+Use `--platform=linux/amd64` on Apple Silicon — the image is amd64-only.
+
+---
+
 ## Releasing a new version
 
 The pipeline is **tag-driven**. Pushing a `vX.Y.Z` git tag to this repo

--- a/README.md
+++ b/README.md
@@ -99,6 +99,125 @@ Open the Ideations tab and describe what you want to build. Your AI agent can no
 
 The first time you sign in, a **4-slide onboarding tour** introduces the platform: welcome, quick-start, AI-assistant binding, and a final nudge to ask your agent to start an ideation. Dismissable; never shown again.
 
+## Run with Docker
+
+Prefer not to manage a Python install? A signed image is published to GitHub Container Registry on every release.
+
+### One-liner (published image)
+
+```bash
+docker run -d --name okto-pulse \
+  -e HOST=0.0.0.0 \
+  -e MCP_HOST=0.0.0.0 \
+  -p 8100:8100 \
+  -p 8101:8101 \
+  -v okto-pulse-data:/data \
+  ghcr.io/oktolabsai/okto-pulse:latest
+```
+
+Then open `http://localhost:8100` and find the bootstrap API key with:
+
+```bash
+docker exec okto-pulse okto-pulse api-key
+```
+
+The MCP endpoint is at `http://localhost:8101/mcp?api_key=<key>`.
+
+### Image tags
+
+| Tag | Mutability | Use |
+|-----|------------|-----|
+| `:0.1.12` | immutable | exact pin (recommended for prod) |
+| `:0.1` | mutable | minor track — picks up `0.1.x` patches |
+| `:latest` | mutable | floating |
+| `:sha-<short>` | immutable | hard SHA pin (for forensic / debugging) |
+
+Verify the image was built by the official release pipeline (Sigstore keyless signature):
+
+```bash
+cosign verify ghcr.io/oktolabsai/okto-pulse:0.1.12 \
+  --certificate-identity-regexp 'https://github.com/OktoLabsAI/okto-pulse/.*' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+```
+
+SLSA provenance and CycloneDX SBOM ship as image attestations:
+
+```bash
+cosign download attestation ghcr.io/oktolabsai/okto-pulse:0.1.12 \
+  --predicate-type slsaprovenance
+cosign download attestation ghcr.io/oktolabsai/okto-pulse:0.1.12 \
+  --predicate-type cyclonedx
+```
+
+### Compose
+
+The repo ships two compose files. Pick the one that matches your workflow.
+
+**`docker-compose.prod.yml`** — pulls a pinned `okto-pulse==X.Y.Z` from PyPI. Build context is this repo only (no sibling clone needed).
+
+```bash
+docker compose -f docker-compose.prod.yml build
+docker compose -f docker-compose.prod.yml up -d
+docker compose -f docker-compose.prod.yml logs -f
+```
+
+**`docker-compose.yml`** — builds wheels from the local `okto-pulse-core/` sibling. Use this when you're hacking on the engine or pulse together. Requires `okto-pulse-core/` cloned next to `okto-pulse/`.
+
+```bash
+# from okto-pulse/
+docker compose build
+docker compose up -d
+docker compose logs -f
+```
+
+To regenerate `.mcp.json` and copy it onto your host so Claude Code / Cursor / Windsurf can find the running MCP server:
+
+```bash
+docker compose exec okto-pulse okto-pulse init --agents claude
+docker compose cp okto-pulse:/app/.mcp.json ./.mcp.json
+```
+
+### Ports & networking
+
+| Port | Purpose | Inside-container default | Notes |
+|------|---------|--------------------------|-------|
+| 8100 | API + Frontend (SPA) | `127.0.0.1:8100` | Set `HOST=0.0.0.0` to expose across the docker network. |
+| 8101 | MCP server (HTTP) | `127.0.0.1:8101` | Set `MCP_HOST=0.0.0.0` to expose so AI tools outside the container can connect. |
+
+Both compose files set `HOST=0.0.0.0` and `MCP_HOST=0.0.0.0` already and bind host ports to `127.0.0.1` only — the container is reachable from your machine but not from the wider network. If you need access from a LAN host, change the `ports:` mapping to `"0.0.0.0:8100:8100"` etc., and put the host behind a real reverse proxy / auth layer.
+
+### Environment variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `HOST` | `127.0.0.1` | API/UI uvicorn bind host. **Set to `0.0.0.0` in containers.** |
+| `MCP_HOST` | `127.0.0.1` | MCP uvicorn bind host. **Set to `0.0.0.0` in containers.** |
+| `DATA_DIR` | `~/.okto-pulse` | Where SQLite + KG live. Set to `/data` in containers and mount a volume. |
+| `KG_BASE_DIR` | derived from `DATA_DIR` | Per-board knowledge graphs. Same `/data` in containers. |
+| `HF_HOME` | `~/.cache/huggingface` | Sentence-transformers cache. Pre-warmed at `/opt/hf-cache` in the image. |
+| `MCP_TRACE_ENABLED` | unset (off) | Set to `1` to record every MCP tool call to `${MCP_TRACE_DIR}/session_*.jsonl` for replay testing. |
+| `MCP_TRACE_DIR` | `${DATA_DIR}/mcp_traces` | Where MCP traces are written when `MCP_TRACE_ENABLED=1`. |
+
+### Persistence
+
+The container writes everything to `/data` (`DATA_DIR=/data`):
+
+- `/data/data/pulse.db` — SQLite database (boards, agents, specs, sprints, cards, knowledge entries, …)
+- `/data/boards/<board-id>/graph.lbug` — embedded LadybugDB knowledge graph per board
+- `/data/uploads/` — attachment storage
+- `/data/mcp_traces/` — MCP request traces (only when `MCP_TRACE_ENABLED=1`)
+
+Mount `/data` to a named volume (recommended) or a host path. Do **not** mount over the bundled `/opt/hf-cache` — the embedding model is baked into the image at build time so the runtime is offline-capable.
+
+### Image internals (short version)
+
+- Base: `python:3.14-slim` pinned by digest.
+- Two build targets:
+  - **`local-runtime`** — wheels built from sibling source repos. Used by `docker-compose.yml` and the release pipeline's smoke step. Build context must be the parent of `okto-pulse/` so Docker can `COPY okto-pulse/` and `COPY okto-pulse-core/`.
+  - **`pypi-runtime`** — installs `okto-pulse==<ARG OKTO_PULSE_VERSION>` from PyPI. Used by `docker-compose.prod.yml`.
+- The `all-MiniLM-L6-v2` sentence-transformers model is downloaded at build time and its `model.safetensors` SHA256 is verified against a pinned constant — the resulting image runs offline.
+- See [`Dockerfile`](./Dockerfile) for the full build graph.
+
 ## CLI Commands
 
 | Command | Description |


### PR DESCRIPTION
Cherry-picked the lone commit from the now-retired `dev` branch onto `develop` so we don't lose the Docker architecture docs.

## Context
- `dev` branch is being retired in favor of `develop`
- Commit `9716bda` (originally on `dev`) had docs about Docker architecture not present in `develop`
- This PR preserves that work before `dev` is deleted

## Changes
- `README.md` + `CLAUDE.md`: Docker architecture explanation

## Verification
- Cherry-pick clean (auto-merge in README.md, no conflicts)
- Source commit: 9716bda "docs: explain Docker architecture in README + CLAUDE.md"

