### PR TITLE
fix(mcp): honor MCP_HOST env var in dual-port runner

### DIFF
--- a/src/okto_pulse/community/main.py
+++ b/src/okto_pulse/community/main.py
@@ -583,7 +583,11 @@ async def _serve_dual(api_port: int, mcp_port: int) -> None:
 
     mcp_config = uvicorn.Config(
         build_mcp_asgi_app(),
-        host="127.0.0.1",
+        # Read host from environment (set by Docker / compose) or fall back to
+        # loopback so a stray process doesn't accidentally expose the MCP
+        # server. Override via MCP_HOST=0.0.0.0 in docker-compose.yml when
+        # port-mapping is required from outside the container.
+        host=os.environ.get("MCP_HOST", "127.0.0.1"),
         port=mcp_port,
         ws="wsproto",
         log_level="info",


### PR DESCRIPTION
Fixes #27. Companion to OktoLabsAI/okto-pulse-core#25.

## Problem

`_serve_dual` (introduced in ecd9b345 / 0.1.5 dual-port refactor) hardcoded `host="127.0.0.1"` for the MCP `uvicorn.Config` while correctly reading `settings.host` for the API config 16 lines above. Result: `MCP_HOST=0.0.0.0` in `docker-compose.yml` has no effect — uvicorn binds to container loopback and Docker port-forwards silently drop external traffic.

## Repro

GHCR image `0.1.13` with the standard compose binding `9101:8101` — `curl` from outside the container times out, while `docker exec curl 127.0.0.1:8101` works fine.

## Fix

Read `os.environ.get("MCP_HOST", settings.host)` for the MCP uvicorn.Config so docker-compose's `MCP_HOST=0.0.0.0` is actually honored on the dual-port path.

## Companion

`okto-pulse-core` #25 (merged) restores the env-var read in the **standalone** path. This PR closes the gap on the **dual-port** path. Together they fix the regression on both code paths.

## Test

Verified manually against running container at `192.168.31.154:9101` — MCP now returns the expected 406 for un-Accepted requests instead of timing out.
