### PR TITLE
chore: trivyignore CVE-2026-45447 (openssl deb13u1, fix in deb13u2)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -14,3 +14,10 @@
 
 CVE-2026-32871
 CVE-2026-27124
+
+# CVE-2026-45447: OpenSSL PKCS#7/S-MIME issue in the debian 13.5 base image
+# (libssl3t64 / openssl / openssl-provider-legacy 3.5.6-1~deb13u1). Fix
+# exists in 3.5.6-1~deb13u2; temporary ignore until the base image picks it
+# up. Failed the v0.2.3 release trivy gate (run 27315635576). Remove once
+# the rebuilt base includes deb13u2.
+CVE-2026-45447


### PR DESCRIPTION
The v0.2.3 release failed at the trivy gate on 3 HIGH findings, all the same CVE-2026-45447 in the debian 13.5 base image (libssl3t64/openssl/openssl-provider-legacy 3.5.6-1~deb13u1, fixed in deb13u2). Temporary ignore until the base image carries the patched package; remove the entry then. Failed run: https://github.com/OktoLabsAI/okto-pulse/actions/runs/27315635576