### PR TITLE
docs: add permission governance changeset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- A recursive permission editor that renders every one of the 397 permission
+  leaves exposed by the application, with a full-coverage regression.
+- Reviewer-separation controls in both Board settings and Global Default Board
+  Configuration.
+- Route and UI regressions for board sharing, permission presets and canonical
+  authorization projection.
+
+### Changed
+
+- REST and UI authorization now consume the centralized Core operation policy
+  and the canonical namespaces for agent, board administration and sharing,
+  permission presets, default configuration, design system, runtime, metrics,
+  amendments and Knowledge Graph operations.
+- The bundled frontend distribution was rebuilt from the reconciled source.
+
+### Fixed
+
+- Permission UI state now refreshes reliably when the selected role or board
+  changes.
+- Inline guidelines no longer present an inapplicable unlink action.
+- Guideline import and export preserve evaluation metrics, immutable identity
+  and version creation semantics for repeated IDs.
+
+### Validation
+
+- The Board E2E flow proves traceability and semantic-guideline policy blocks,
+  then completes successfully after current independent assessment evidence.
+- Ruff, 65 focused Community regressions, frontend build, distribution
+  verification and the lint ratchet pass after reconciliation with `develop`.
+
 ## [0.3.1] - 2026-07-27
 
 ### Added

--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -16,6 +16,24 @@ Spec checklist execution state.
 - Paired-wheel provenance and installed inventory gates ratchet the exposed MCP
   contract to 312 tools (304 canonical and 8 aliases).
 
+#### Permission-governance hardening changeset — 2026-08-08
+
+- The permission editor is recursive and proves coverage of all 397 permission
+  leaves exposed by the application.
+- REST and UI routes project the centralized Core operation policy, including
+  exact denial, legacy fallback and role semantics for board sharing, presets,
+  defaults and administrative operations.
+- Reviewer separation is configurable from Board settings and Global Default
+  Board Configuration; the E2E board was validated with board enforcement off
+  and the global default set to enforce.
+- Guideline import and export cover global and inline guidelines, with and
+  without evaluation metrics, including repeated-ID imports that create a new
+  immutable version.
+- Board E2E validation proves both the traceability and semantic-guideline
+  blocks before completing the cards with current independent assessment
+  evidence. Ruff, 65 focused regressions, frontend build, distribution
+  verification and the lint ratchet pass on the reconciled release branch.
+
 
 ### 0.3.0
 


### PR DESCRIPTION
## Summary
- records the Community permission-governance changeset
- documents recursive UI coverage and Board E2E validation
- updates the v0.3.1 release notes

## Validation
- git diff --check