### PR TITLE
fix: add dev extras to pyproject.toml and fix stale references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: F16 SaaS closure ratchet
         run: |
           python -m pip install --upgrade pip
-          pip install -e okto-pulse-core -e okto-pulse pytest pytest-asyncio build uv
+          pip install -e okto-pulse-core -e "okto-pulse[dev]"
           pytest --noconftest -q okto-pulse-core/tests/test_f16_saas_closure_report.py okto-pulse/tests/test_f16_saas_closure.py
           okto-pulse-saas-closure --core-repo okto-pulse-core --community-repo okto-pulse --format text
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,7 +324,7 @@ build time so the runtime is offline-capable.
 - `.github/workflows/ci.yml` — PR + main: pytest gate is currently dropped
   (same caveat as release); runs build verify on the Dockerfile to catch
   Dockerfile/dep regressions before tagging
-- `.github/workflows/cla.yml` — CLA signing, do not touch
+- `.github/workflows/claude.yml` — CLA signing, do not touch
 
 ## Out of scope (deliberately)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,14 @@ dependencies = [
     "sentence-transformers>=2.5.0,<6.0.0",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0,<9.0.0",
+    "pytest-asyncio>=0.23.0,<1.0.0",
+    "build>=1.0.0,<2.0.0",
+    "uv>=0.1.0",
+]
+
 [project.urls]
 Homepage = "https://github.com/OktoLabsAI/okto-pulse"
 Documentation = "https://github.com/OktoLabsAI/okto-pulse#readme"


### PR DESCRIPTION
## Summary

Fixes #70. `CLAUDE.md` tells contributors to run `pip install -e ".[dev]"` but `pyproject.toml` defines no `dev` extra, so pytest is never installed.

### Changes

- **pyproject.toml**: Added `[project.optional-dependencies]` `dev` group with pytest, pytest-asyncio, build, uv
- **CLAUDE.md:327**: Fixed `cla.yml` → `claude.yml` (the actual workflow filename)
- **ci.yml:76**: Updated to use `okto-pulse[dev]` instead of listing packages by hand

### Verification

- `pip install -e ".[dev]"` now installs pytest and friends
- `claude.yml` exists in `.github/workflows/`, `cla.yml` does not

Closes #70